### PR TITLE
Implement toString() method, add "unit" property, update build tools. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-28.0.3
+    - android-28
 before_script:
   - chmod +x gradlew
 script:

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Add the dependency to your `build.gradle`:
 
 ```groovy
 dependencies {
-    compile 'com.github.kizitonwose.time:time:1.0.1'
+    compile 'com.github.kizitonwose.time:time:1.0.2'
 }
 ```
 
@@ -246,7 +246,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    compile 'com.github.kizitonwose.time:time-android:1.0.1'
+    compile 'com.github.kizitonwose.time:time-android:1.0.2'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.1.51'
+    ext.kotlin_version = '1.2.71'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.palantir:jacoco-coverage:0.4.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 10 17:12:41 PDT 2018
+#Sat Oct 20 23:15:15 WAT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/time-android/build.gradle
+++ b/time-android/build.gradle
@@ -5,13 +5,13 @@ apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.kizitonwose'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -33,6 +33,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation project(':time')
 }

--- a/time/src/main/kotlin/com/kizitonwose/time/Time.kt
+++ b/time/src/main/kotlin/com/kizitonwose/time/Time.kt
@@ -15,7 +15,7 @@ interface TimeUnit {
 }
 
 
-class Interval<out T : TimeUnit>(value: Number, val factory: () -> T) : Serializable {
+class Interval<out T : TimeUnit>(value: Number, factory: () -> T) : Serializable {
 
     companion object {
         inline operator fun <reified K : TimeUnit> invoke(value: Number) = Interval(value) {
@@ -53,30 +53,30 @@ class Interval<out T : TimeUnit>(value: Number, val factory: () -> T) : Serializ
 
     inline fun <reified OtherUnit : TimeUnit> converted(): Interval<OtherUnit> {
         val otherInstance = OtherUnit::class.java.newInstance()
-        return Interval(value * factory().conversionRate(otherInstance))
+        return Interval(value * unit.conversionRate(otherInstance))
     }
 
     operator fun plus(other: Interval<TimeUnit>): Interval<T> {
-        val newValue = value + other.value * other.factory().conversionRate(factory())
-        return Interval(newValue) { factory() }
+        val newValue = value + other.value * other.unit.conversionRate(unit)
+        return Interval(newValue) { unit }
     }
 
     operator fun minus(other: Interval<TimeUnit>): Interval<T> {
-        val newValue = value - other.value * other.factory().conversionRate(factory())
-        return Interval(newValue) { factory() }
+        val newValue = value - other.value * other.unit.conversionRate(unit)
+        return Interval(newValue) { unit }
     }
 
     operator fun times(other: Number): Interval<T> {
-        return Interval(value * other.toDouble()) { factory() }
+        return Interval(value * other.toDouble()) { unit }
     }
 
     operator fun div(other: Number): Interval<T> {
-        return Interval(value / other.toDouble()) { factory() }
+        return Interval(value / other.toDouble()) { unit }
     }
 
-    operator fun inc() = Interval(value + 1) { factory() }
+    operator fun inc() = Interval(value + 1) { unit }
 
-    operator fun dec() = Interval(value - 1) { factory() }
+    operator fun dec() = Interval(value - 1) { unit }
 
     operator fun compareTo(other: Interval<TimeUnit>)
             = inMilliseconds.value.compareTo(other.inMilliseconds.value)

--- a/time/src/main/kotlin/com/kizitonwose/time/Time.kt
+++ b/time/src/main/kotlin/com/kizitonwose/time/Time.kt
@@ -78,11 +78,9 @@ class Interval<out T : TimeUnit>(value: Number, factory: () -> T) : Serializable
 
     operator fun dec() = Interval(value - 1) { unit }
 
-    operator fun compareTo(other: Interval<TimeUnit>)
-            = inMilliseconds.value.compareTo(other.inMilliseconds.value)
+    operator fun compareTo(other: Interval<TimeUnit>) = inMilliseconds.value.compareTo(other.inMilliseconds.value)
 
-    operator fun contains(other: Interval<TimeUnit>)
-            = inMilliseconds.value >= other.inMilliseconds.value
+    operator fun contains(other: Interval<TimeUnit>) = inMilliseconds.value >= other.inMilliseconds.value
 
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is Interval<TimeUnit>) return false
@@ -92,7 +90,11 @@ class Interval<out T : TimeUnit>(value: Number, factory: () -> T) : Serializable
     override fun hashCode() = inMilliseconds.value.hashCode()
 
     override fun toString(): String {
-        return "$value ${unit::class.java.simpleName}"
+        val unitString = unit::class.java.simpleName.toLowerCase()
+        val isWhole = value % 1 == 0.0
+        return (if (isWhole) longValue.toString() else value.toString())
+                .plus(" ")
+                .plus(if (value == 1.0) unitString else unitString.plus("s"))
     }
 }
 

--- a/time/src/main/kotlin/com/kizitonwose/time/Time.kt
+++ b/time/src/main/kotlin/com/kizitonwose/time/Time.kt
@@ -72,9 +72,9 @@ class Interval<out T : TimeUnit>(value: Number, val factory: () -> T) : Serializ
         return Interval(value / other.toDouble()) { factory() }
     }
 
-    operator fun inc() = Interval(value + 1, { factory() })
+    operator fun inc() = Interval(value + 1) { factory() }
 
-    operator fun dec() = Interval(value - 1, { factory() })
+    operator fun dec() = Interval(value - 1) { factory() }
 
     operator fun compareTo(other: Interval<TimeUnit>)
             = inMilliseconds.value.compareTo(other.inMilliseconds.value)
@@ -88,6 +88,10 @@ class Interval<out T : TimeUnit>(value: Number, val factory: () -> T) : Serializ
     }
 
     override fun hashCode() = inMilliseconds.value.hashCode()
+
+    override fun toString(): String {
+        return "$value ${unit::class.java.simpleName}"
+    }
 }
 
 

--- a/time/src/main/kotlin/com/kizitonwose/time/Time.kt
+++ b/time/src/main/kotlin/com/kizitonwose/time/Time.kt
@@ -23,6 +23,8 @@ class Interval<out T : TimeUnit>(value: Number, val factory: () -> T) : Serializ
         }
     }
 
+    val unit: T = factory()
+
     val value = value.toDouble()
 
     val longValue = Math.round(this.value)


### PR DESCRIPTION
- Add `unit` property in `Interval` class to retrieve time unit.
- Implement `toString()` method in `Interval` class.
- Update build tools.

Fixes #4 